### PR TITLE
Raise log level to avoid exceptions going unnoticed

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/http/WroFilter.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/http/WroFilter.java
@@ -351,13 +351,13 @@ public class WroFilter
    *          {@link Exception} thrown during request processing.
    */
   protected void onException(final Exception e, final HttpServletResponse response, final FilterChain chain) {
-    LOG.debug("Exception occured", e);
+    LOG.error("Exception occured", e);
     try {
-      LOG.debug("Cannot process. Proceeding with chain execution.");
+      LOG.warn("Cannot process. Proceeding with chain execution.");
       chain.doFilter(Context.get().getRequest(), response);
     } catch (final Exception ex) {
       // should never happen (use debug level to suppress unuseful logs)
-      LOG.debug("Error while chaining the request", e);
+      LOG.debug("Error while chaining the request", ex);
     }
   }
 


### PR DESCRIPTION
I don't think I understand the reasoning behind the existing code. I just spent 2h digging through Spring Web MVC Code that was invoked because `WroFilter` failed with an exception that went unnoticed. So, `WroFilter` failed and later something further down the processing chain (filters or servlets) failed.
Additional remarks:
- I would even claim that if `WroFilter` fails with an exception it shouldn't continue processing the filter chain. I don't see how something useful could ever come out of the chain if wro4j processing failed.
- I don't understand the comment in the `catch` block. My thinking is exactly opposite...particularly _because_ something should never happen I'd want to see this logged on ERROR level.