### PR TITLE
JSMin test case for function returing a RegExp (fails with an UnterminatedRegExpLiteralException)

### DIFF
--- a/wro4j-core/src/test/java/ro/isdc/wro/model/resource/processor/TestJsMinProcessor.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/model/resource/processor/TestJsMinProcessor.java
@@ -180,6 +180,11 @@ public class TestJsMinProcessor {
     jsmin("var r = /a/*comment");
   }
   
+  @Test
+  public void shouldProcessFunctionReturningRegExp() throws Exception {
+      jsmin("function getFullDateMatcher { return /^\\d?\\d([.\\/-])\\d?\\d1\\d\\d\\d?\\d?/; }");
+  }
+  
   private String jsmin(final String inputScript)
       throws Exception {
     final StringReader reader = new StringReader(inputScript);
@@ -189,4 +194,6 @@ public class TestJsMinProcessor {
     new JSMin(is, os).jsmin();
     return writer.toString();
   }
+  
+  
 }


### PR DESCRIPTION
Hi Folks,
we are using WRO4J 1.7.8 with JSMin to compress our JS files. JSMin throws an UnterminatedRegExpLiteralException when following JS code is processed:
`
function getFullDateMatcher() {        
    return /^\d?\d([.\/-])\d?\d\1\d\d\d?\d?/;
}
`
I forked the WRO4J "1.7.x" branch and added a test method to the TestJsMinProcessor class. Can you please have a look on this issue?
