### PR TITLE
correcting overly-aggressive regex

### DIFF
--- a/wro4j-core/src/main/resources/ro/isdc/wro/util/regexp.properties
+++ b/wro4j-core/src/main/resources/ro/isdc/wro/util/regexp.properties
@@ -7,7 +7,7 @@ cssUrlRewrite=(?is)src\b\s*=\s*['"](.*?)['"]|(?:@import\s*)?\burl\b\s*\(\s*['"]?
 cssImport=(?i)@import\b\s*(?:(?:url)?\(?\s*["']?)([^)"']*)["']?\)?;?
 lessCssImport=(?i)@import(?:-once|-multiple)?\b\s*(?:(?:url)?\(?\s*["']?)([^)"']*)["']?\)?;?
 
-cssImportFromComments=(?m)(?:/*/\*(?:[^*]|(?:\*+[^*/]))*+\*+/)|(?:^\s*//.*@import.*+)
+cssImportFromComments=(?m)(?:^\s*/\*(?:[^*]|(?:\*+[^*/]))*+\*+/)|(?:^\s*//.*@import.*+)
 
 # Search for variables definition. Example: @variables { var1: white; var2: #fff; } 
 cssVariables.definition=(?is)@variables\s*\{(.*?)\}

--- a/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expected/jquery-ui-1.8.2.custom.css
+++ b/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expected/jquery-ui-1.8.2.custom.css
@@ -9,25 +9,13 @@
 
 .ui-helper-zfix { width: 100%; height: 100%; top: 0; left: 0; position: absolute; opacity: 0; filter:Alpha(Opacity=0); }
 
-
-
 .ui-state-disabled { cursor: default !important; }
-
-
-
 
 
 .ui-icon { display: block; text-indent: -99999px; overflow: hidden; background-repeat: no-repeat; }
 
 
-
-
-
 .ui-widget-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
-
-
-
-
 
 
 .ui-widget { font-family: Verdana,Arial,sans-serif; font-size: 1.0em; }

--- a/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expected/shouldNotIncludeImportsFromComments.css
+++ b/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expected/shouldNotIncludeImportsFromComments.css
@@ -1,4 +1,4 @@
 body {
   font-family: Verdana;
-  
+
 }

--- a/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/support/cssimport/expectedRemoveImportsFromComments/simpleAndMultilineComments.css
+++ b/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/support/cssimport/expectedRemoveImportsFromComments/simpleAndMultilineComments.css
@@ -1,3 +1,6 @@
+//** deleting the comment removes the problem
+@body-bg:               #fff;
+
 @import  "variables.less";
 @mainColor: blue;
 


### PR DESCRIPTION
It seems that the fix for https://github.com/wro4j/wro4j/issues/976 ends up creating a regex that's a bit too aggressive. For example, the less:

```
.this_always_works {
    margin-left: 10px;
}

//** single-line comment

.this_is_skipped_if_there_is_a_block_comment_below {
    margin-left: 10px;
}

/* */

.this_always_works_too {
    margin-left: 10px;
}
```

is transformed to:

```
.this_always_works {
    margin-left: 10px;
}

.this_always_works_too {
    margin-left: 10px;
}
```

but should be:

```
.this_always_works {
    margin-left: 10px;
}

.this_is_skipped_if_there_is_a_block_comment_below {
    margin-left: 10px;
}

.this_always_works_too {
    margin-left: 10px;
}
```

The `cssImportFromComments` regex appears to be trying to strip block comments but incorrectly matches single line comments starting with '//*'.

I've been unable to process Bootstrap 3.3.6 without this patch while using:
```
preProcessors=lessCssImport
postProcessors=less4j,jsMin
```

I've very new to working with less & css in general, so please correct me if any of my assumptions about how it is all supposed to work together is wrong.