### PR TITLE
This is "an" approach to the Sass::Engine to finding the path to @import

### DIFF
--- a/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/expected/test2.css
+++ b/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/expected/test2.css
@@ -1,4 +1,4 @@
-/* Copyright ... */
+/*! Copyright ... */
 @font-face {
   font-family: Roboto;
   font-weight: 300;

--- a/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/expected/test2.css
+++ b/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/expected/test2.css
@@ -1,4 +1,4 @@
-/*! Copyright ... */
+/* Copyright ... */
 @font-face {
   font-family: Roboto;
   font-weight: 300;

--- a/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/expected/testImport.css
+++ b/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/expected/testImport.css
@@ -1,0 +1,2 @@
+li {
+  background: white; }

--- a/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/test/_test.scss
+++ b/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/test/_test.scss
@@ -1,0 +1,4 @@
+// test import
+li {
+  background: white;
+}

--- a/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/test/testImport.css
+++ b/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/processor/rubysasscss/test/testImport.css
@@ -1,0 +1,1 @@
+@import "test";

--- a/wro4j-extensions/src/test/resources/sass.properties
+++ b/wro4j-extensions/src/test/resources/sass.properties
@@ -1,0 +1,1 @@
+loadPaths=/ro/isdc/wro/extensions/processor/rubysasscss/test


### PR DESCRIPTION
Greetings and Happy New Year!

I really like wro4j, it fits well into how I like to write software, I still love java for the backend but want all of the great new capabilities of environments like Rails for building web front ends. 
## I tried to find a way to configure the scss component to support imports and finally decided to modify the RubySassEngine.  I hope you like this change and I would love to continue enhancing it.... later when I am not under such a time crunch.

This is "an" approach to the Sass::Engine to finding the path to @imp…ort directives properly. There are many different ways this could be done. I did it this way to get it done without adding anything to the current function parameters, object constructors or the required libraries.

To use this change add a file called sass.properties at the top level of the classpath for a deployment.  In that file you may optionally include a property called loadPaths that contains a list of sub-directories below the location of the .properties file.

RubySassEngine.java will add the location of the properties file and all directories defined in the loadPaths properties to the :load_paths option that will be passed to Sass::Engine.

For example is the sass.properties file is locations in /test/webpp/WEB-INF/classes

And the file includes the entry
loadPaths=/sass

The the following will be passes to the Sass::Engine
:load_paths => ['/test/webpp/WEB-INF/classes/','/test/webpp/WEB-INF/classes/sass']

Some great enhancements to this approach would be to add logic to pass additional parameters to the Sass::Engine through the properties file and make the logic more dynamic for determining whether to prepend the classpath to the entries in loadPaths
