### PR TITLE
Fixed embedded jars used by Spring Boot

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/locator/wildcard/JarWildcardStreamLocator.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/locator/wildcard/JarWildcardStreamLocator.java
@@ -70,7 +70,7 @@ public class JarWildcardStreamLocator
   private boolean isSupported(final File jarPath) {
     LOG.debug("jarPath: {}", jarPath);
     for (final String supportedExtension : SUPPORTED_EXTENSIONS) {
-      if (jarPath.getPath().endsWith(supportedExtension)) {
+      if (jarPath.getPath().endsWith(supportedExtension) && !jarPath.getPath().contains("!/")) {
         return true;
       }
     }

--- a/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/http/handler/wroModel_external.json
+++ b/wro4j-extensions/src/test/resources/ro/isdc/wro/extensions/http/handler/wroModel_external.json
@@ -1,17 +1,6 @@
 {
   "groups": [
     {
-      "name": "test",
-      "resources": [
-        {
-          "type": "JS",
-          "minimize": true,
-          "uri": "test.js",
-          "proxyUri": "/wro/?wroAPI=wroResources&id=test.js"
-        }
-      ]
-    },
-    {
       "name": "external",
       "resources": [
         {
@@ -25,6 +14,17 @@
           "minimize": true,
           "uri": "http://www.site.com/style.css",
           "proxyUri": "http://www.site.com/style.css"
+        }
+      ]
+    },
+    {
+      "name": "test",
+      "resources": [
+        {
+          "type": "JS",
+          "minimize": true,
+          "uri": "test.js",
+          "proxyUri": "/wro/?wroAPI=wroResources&id=test.js"
         }
       ]
     }


### PR DESCRIPTION
Spring Boot uses JAR inside JAR technique to package dependencies inside final artifacts.
wro4j classpath scanner fails to correctly process such case and throws an exception.
This pull request address the issue by disabling JarWildcardStreamLocator on such jar-in-jar files, because needed resources are usually in the main (root-level) JAR.