### PR TITLE
Lower log level when falling back to default config

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/config/factory/ServletContextPropertyWroConfigurationFactory.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/config/factory/ServletContextPropertyWroConfigurationFactory.java
@@ -68,7 +68,7 @@ public class ServletContextPropertyWroConfigurationFactory
       Validate.notNull(propertyStream);
       props.load(propertyStream);
     } catch (final Exception e) {
-      LOG.error("[FAIL] Cannot read properties file stream from default location: {}. Using default configuration.", getConfigPath());
+      LOG.warn("[WARN] Cannot read properties file stream from default location: {}. Using default configuration.", getConfigPath());
     } finally {
       IOUtils.closeQuietly(propertyStream);
     }


### PR DESCRIPTION
If you can still continue without serious side effects logging an error is IMO inappropriate. We configure wro4j with Spring like so

```
<!-- https://code.google.com/p/wro4j/wiki/ConfigureWro4jViaSpring -->
<bean id="wroFilter" class="ro.isdc.wro.http.ConfigurableWroFilter">
  <property name="properties" ref="wroProperties" />
</bean>
<bean id="wroProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
  <property name="properties">
    <props>
      <prop key="debug">${wro4j.debug}</prop>
```
Therefore, there's no `/WEB-INF/wro.properties`. System administrators get constantly confused by the error message when they boot our application.