### PR TITLE
`RubySassEngine` crashes with parallel preprocessing

### DIFF
--- a/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/sass/RubySassEngine.java
+++ b/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/sass/RubySassEngine.java
@@ -29,6 +29,7 @@ public class RubySassEngine {
   private static final String RUBY_GEM_REQUIRE = "rubygems";
   private static final String SASS_PLUGIN_REQUIRE = "sass/plugin";
   private static final String SASS_ENGINE_REQUIRE = "sass/engine";
+  private static final Object GLOBAL_LOCK = new Object();
 
   private final Set<String> requires;
 
@@ -59,13 +60,15 @@ public class RubySassEngine {
    * @param content
    *          the Sass content to process.
    */
-  public synchronized String process(final String content) {
+  public String process(final String content) {
     if (StringUtils.isEmpty(content)) {
       return StringUtils.EMPTY;
     }
     try {
-      final ScriptEngine rubyEngine = new ScriptEngineManager().getEngineByName("jruby");
-      return rubyEngine.eval(buildUpdateScript(content)).toString();
+      synchronized(GLOBAL_LOCK) {
+        final ScriptEngine rubyEngine = new ScriptEngineManager().getEngineByName("jruby");
+        return rubyEngine.eval(buildUpdateScript(content)).toString();
+      }
     } catch (final ScriptException e) {
       throw new WroRuntimeException(e.getMessage(), e);
     }

--- a/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/sass/RubySassEngine.java
+++ b/wro4j-extensions/src/main/java/ro/isdc/wro/extensions/processor/support/sass/RubySassEngine.java
@@ -35,6 +35,8 @@ public class RubySassEngine {
 
   public RubySassEngine() {
     System.setProperty("org.jruby.embed.compat.version", "JRuby1.9");
+    System.setProperty("org.jruby.embed.compilemode", "jit");
+    System.setProperty("org.jruby.embed.sharing.variables", "false");
     requires = new LinkedHashSet<String>();
     requires.add(RUBY_GEM_REQUIRE);
     requires.add(SASS_PLUGIN_REQUIRE);


### PR DESCRIPTION
I see the following errors with 1.7.9 while building using `mvn` with `parallelPreprocessing=true`.
`RubySassEngine` crashes while processing`sass` files.
I don't see the errors with 1.7.7. This error seems to be due to JRuby 9.0.0.0.
JRuby 9.0.0.0 would have different behavior with multi-thread from 1.7.x.
Adding global lock solves the issue for me.

```
[ERROR] Failed to process the resource: ro.isdc.wro.model.resource.Resource@27b2faa6[CSS,/asset/common.scss,true] using processor: ro.isdc.wro.extensions.processor.css.RubySassCssProcessor@5beea545. Reason: java.lang.NullPointerException
[ERROR] Failed to process the resource: ro.isdc.wro.model.resource.Resource@7adad1f1[CSS,/asset/common.scss,true] using processor: ro.isdc.wro.extensions.processor.css.RubySassCssProcessor@5beea545. Reason: java.lang.NullPointerException
[ERROR] Failed to process the resource: ro.isdc.wro.model.resource.Resource@219b95ca[CSS,/asset/common.scss,true] using processor: ro.isdc.wro.extensions.processor.css.RubySassCssProcessor@5beea545. Reason: java.lang.NullPointerException
[INFO] processing group: xxxxxx.css
[ERROR] Exception occured while processing: ro.isdc.wro.WroRuntimeException: java.lang.NullPointerException, class: ro.isdc.wro.WroRuntimeException,caused by: javax.script.ScriptException
[INFO] processing group: xxxxx.js
[INFO] processing group: xxxxx.css
ro.isdc.wro.WroRuntimeException: java.lang.NullPointerException
        at ro.isdc.wro.extensions.processor.support.sass.RubySassEngine.process(RubySassEngine.java:70)
        at ro.isdc.wro.extensions.processor.css.RubySassCssProcessor.process(RubySassCssProcessor.java:59)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.LazyProcessorDecorator.process(LazyProcessorDecorator.java:49)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.SupportAwareProcessorDecorator.process(SupportAwareProcessorDecorator.java:39)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.ExceptionHandlingProcessorDecorator.process(ExceptionHandlingProcessorDecorator.java:56)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.BenchmarkProcessorDecorator.process(BenchmarkProcessorDecorator.java:44)
        at ro.isdc.wro.model.resource.processor.decorator.ProcessorDecorator.process(ProcessorDecorator.java:86)
        at ro.isdc.wro.model.resource.processor.decorator.DefaultProcessorDecorator.process(DefaultProcessorDecorator.java:42)
        at ro.isdc.wro.model.group.processor.PreProcessorExecutor$2.process(PreProcessorExecutor.java:228)
        at ro.isdc.wro.model.group.processor.PreProcessorExecutor.applyPreProcessors(PreProcessorExecutor.java:207)
        at ro.isdc.wro.model.group.processor.PreProcessorExecutor.access$100(PreProcessorExecutor.java:49)
        at ro.isdc.wro.model.group.processor.PreProcessorExecutor$1.call(PreProcessorExecutor.java:133)
        at ro.isdc.wro.model.group.processor.PreProcessorExecutor$1.call(PreProcessorExecutor.java:129)
        at ro.isdc.wro.config.support.ContextPropagatingCallable.call(ContextPropagatingCallable.java:62)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: javax.script.ScriptException: java.lang.NullPointerException
        at org.jruby.embed.jsr223.JRubyEngine.wrapException(JRubyEngine.java:104)
        at org.jruby.embed.jsr223.JRubyEngine.eval(JRubyEngine.java:93)
        at org.jruby.embed.jsr223.JRubyEngine.eval(JRubyEngine.java:142)
        at ro.isdc.wro.extensions.processor.support.sass.RubySassEngine.process(RubySassEngine.java:68)
        ... 24 more
Caused by: java.lang.NullPointerException
        at org.jruby.RubyModule.defineAnnotatedMethodsIndividually(RubyModule.java:968)
        at org.jruby.RubyModule.defineAnnotatedMethods(RubyModule.java:887)
        at org.jruby.RubyBasicObject.createBasicObjectClass(RubyBasicObject.java:218)
        at org.jruby.Ruby.initRoot(Ruby.java:1367)
        at org.jruby.Ruby.init(Ruby.java:1208)
        at org.jruby.Ruby.newInstance(Ruby.java:331)
        at org.jruby.embed.internal.AbstractLocalContextProvider.getGlobalRuntime(AbstractLocalContextProvider.java:82)
        at org.jruby.embed.internal.SingletonLocalContextProvider.getRuntime(SingletonLocalContextProvider.java:99)
        at org.jruby.embed.internal.EmbedRubyRuntimeAdapterImpl.runParser(EmbedRubyRuntimeAdapterImpl.java:167)
        at org.jruby.embed.internal.EmbedRubyRuntimeAdapterImpl.parse(EmbedRubyRuntimeAdapterImpl.java:94)
        at org.jruby.embed.ScriptingContainer.parse(ScriptingContainer.java:1243)
        at org.jruby.embed.jsr223.JRubyEngine.eval(JRubyEngine.java:89)
        ... 26 more
```