### PR TITLE
allow any UriLocator to be used for css imports

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/AbstractCssImportPreProcessor.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/AbstractCssImportPreProcessor.java
@@ -26,7 +26,6 @@ import ro.isdc.wro.model.group.Inject;
 import ro.isdc.wro.model.resource.Resource;
 import ro.isdc.wro.model.resource.ResourceType;
 import ro.isdc.wro.model.resource.SupportedResourceType;
-import ro.isdc.wro.model.resource.locator.UrlUriLocator;
 import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
 import ro.isdc.wro.model.resource.processor.ImportAware;
 import ro.isdc.wro.model.resource.processor.ResourcePreProcessor;
@@ -190,7 +189,7 @@ public abstract class AbstractCssImportPreProcessor
    * Build a {@link Resource} object from a found importedResource inside a given resource.
    */
   private Resource createImportedResource(final String resourceUri, final String importUrl) {
-    final String absoluteUrl = UrlUriLocator.isValid(importUrl) ? importUrl
+    final String absoluteUrl = uriLocatorFactory.getInstance(importUrl) != null ? importUrl
         : computeAbsoluteUrl(resourceUri, importUrl);
     return Resource.create(absoluteUrl, ResourceType.CSS);
   }


### PR DESCRIPTION
this change allows to use [Less]CssImporterPreProcessor for `@import`s using any supported locator pattern (e.g `webjar:/`)

fixes https://github.com/wro4j/wro4j/issues/1014