### PR TITLE
allow any UriLocator to be used for css imports

### DIFF
--- a/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/AbstractCssImportPreProcessor.java
+++ b/wro4j-core/src/main/java/ro/isdc/wro/model/resource/processor/impl/css/AbstractCssImportPreProcessor.java
@@ -26,7 +26,6 @@ import ro.isdc.wro.model.group.Inject;
 import ro.isdc.wro.model.resource.Resource;
 import ro.isdc.wro.model.resource.ResourceType;
 import ro.isdc.wro.model.resource.SupportedResourceType;
-import ro.isdc.wro.model.resource.locator.UrlUriLocator;
 import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
 import ro.isdc.wro.model.resource.processor.ImportAware;
 import ro.isdc.wro.model.resource.processor.ResourcePreProcessor;
@@ -190,7 +189,7 @@ public abstract class AbstractCssImportPreProcessor
    * Build a {@link Resource} object from a found importedResource inside a given resource.
    */
   private Resource createImportedResource(final String resourceUri, final String importUrl) {
-    final String absoluteUrl = UrlUriLocator.isValid(importUrl) ? importUrl
+    final String absoluteUrl = uriLocatorFactory.getInstance(importUrl) != null ? importUrl
         : computeAbsoluteUrl(resourceUri, importUrl);
     return Resource.create(absoluteUrl, ResourceType.CSS);
   }

--- a/wro4j-core/src/test/java/ro/isdc/wro/model/resource/locator/custom/CustomClasspathLocatorProvider.java
+++ b/wro4j-core/src/test/java/ro/isdc/wro/model/resource/locator/custom/CustomClasspathLocatorProvider.java
@@ -1,0 +1,45 @@
+package ro.isdc.wro.model.resource.locator.custom;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonMap;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.commons.lang3.Validate;
+
+import ro.isdc.wro.model.resource.locator.ClasspathUriLocator;
+import ro.isdc.wro.model.resource.locator.UriLocator;
+import ro.isdc.wro.model.resource.locator.support.LocatorProvider;
+import ro.isdc.wro.util.StringUtils;
+
+public class CustomClasspathLocatorProvider implements LocatorProvider {
+
+  @Override
+  public Map<String, UriLocator> provideLocators() {
+    UriLocator locator = new CustomClasspathUriLocator();
+    return singletonMap(CustomClasspathUriLocator.ALIAS, locator);
+  }
+
+  private static class CustomClasspathUriLocator extends ClasspathUriLocator {
+
+    public static final String ALIAS = "custom";
+    public static final String PREFIX = format("%s:", ALIAS);
+
+    public boolean accept(final String url) {
+      return url.trim().startsWith(PREFIX);
+    }
+
+    public InputStream locate(final String uri) throws IOException {
+      Validate.notNull(uri, "URI cannot be NULL!");
+      String location = StringUtils.cleanPath(uri.replaceFirst(PREFIX, "")).trim();
+
+      final InputStream is = getClass().getResource(location).openStream();
+      if (is == null) {
+        throw new IOException("Couldn't get InputStream from this resource: " + uri);
+      }
+      return is;
+    }
+  }
+}

--- a/wro4j-core/src/test/resources/META-INF/services/ro.isdc.wro.model.resource.locator.support.LocatorProvider
+++ b/wro4j-core/src/test/resources/META-INF/services/ro.isdc.wro.model.resource.locator.support.LocatorProvider
@@ -1,0 +1,1 @@
+ro.isdc.wro.model.resource.locator.custom.CustomClasspathLocatorProvider

--- a/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expected/importWithCustomLocator.css
+++ b/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expected/importWithCustomLocator.css
@@ -1,0 +1,13 @@
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(http://fonts.gstatic.com/s/opensans/v10/DXI1ORHCpsQm3Vp6mXoaTXhCUOGz7vYGh680lGh-uXM.woff) format('woff');
+}
+
+.test {
+  background:url(data:image/gif;base64,R0lGODlhBQALAIAAAP7//6a9zyH5BAkAAAAALAAAAAAFAAsAAAILDBx4mrfeEJuQogIAOw==) no-repeat 50% 50%;
+}
+.someClass {
+    background: url(http://www.image.com/mobile-sprite.png);
+}

--- a/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expectedLess/importWithCustomLocator.css
+++ b/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/expectedLess/importWithCustomLocator.css
@@ -1,0 +1,13 @@
+@font-face {
+  font-family: 'Open Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Open Sans Light'), local('OpenSans-Light'), url(http://fonts.gstatic.com/s/opensans/v10/DXI1ORHCpsQm3Vp6mXoaTXhCUOGz7vYGh680lGh-uXM.woff) format('woff');
+}
+
+.test {
+  background:url(data:image/gif;base64,R0lGODlhBQALAIAAAP7//6a9zyH5BAkAAAAALAAAAAAFAAsAAAILDBx4mrfeEJuQogIAOw==) no-repeat 50% 50%;
+}
+.someClass {
+    background: url(http://www.image.com/mobile-sprite.png);
+}

--- a/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/test/importWithCustomLocator.css
+++ b/wro4j-core/src/test/resources/ro/isdc/wro/model/resource/processor/cssImport/test/importWithCustomLocator.css
@@ -1,0 +1,3 @@
+@import url(https://raw.githubusercontent.com/alexo/wro4j/gh-pages/asset/test/external.css);
+@import 'custom:/ro/isdc/wro/model/resource/processor/cssImport/test/dataUri.css';
+@import 'absoluteUrl.css';


### PR DESCRIPTION
replaces https://github.com/wro4j/wro4j/pull/1015
fixes https://github.com/wro4j/wro4j/issues/1014

I opened a new PR as the previous one was agains `master` branch and this one is against `1.8.x`.

I had add the CustomClasspathUriLocator as none of the default provider where usable for this test. We have no ServletContext for the ServletContextUriLocator. I did not want to use a *http* resource to test the actual fix as it would not fail with the previous implementation and the ClasspathUriLocator did not work as resources are not available for how ClasspathUriLocator tries to load them.