### PR TITLE
Ensure wro4j manager is destroyed at the end of maven mojos to prevent memory leak in m2e-wro4j

### DIFF
--- a/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
+++ b/wro4j-maven-plugin/src/main/java/ro/isdc/wro/maven/plugin/AbstractWro4jMojo.java
@@ -183,6 +183,9 @@ public abstract class AbstractWro4jMojo
         } catch (final Exception e) {
           throw new MojoExecutionException("Exception in onAfterExecute", e);
         }
+        finally {
+            getWroManager().destroy();
+        }
       }
     }
   }


### PR DESCRIPTION
Finally had time to investigate the issue I had reported in #950 spending time debugging the solution I found was to ensure the wro manager was destroyed at the end of mojo execution.

I did wonder if `Context.destroy()` ought to be called also but it did not appear to affect me here.