### PR TITLE
Replaced google code links with github.com links

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 </head> 
 <body> 
     <div>
-      <img src="http://wiki.wro4j.googlecode.com/git/img/serve.jpg" style="position: fixed;bottom:0; right:0;">
+      <img src="//wro4j.github.io/wro4j/asset/img/serve.jpg" style="position: fixed;bottom:0; right:0;">
       <a href="https://github.com/wro4j/wro4j"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png" alt="Fork me on GitHub"></a>
     </div>
 
@@ -21,7 +21,7 @@
 
     
     <p>
-    <a href="http://code.google.com/p/wro4j">Wro4j</a> is a tool for analysis and optimization of web resources. It brings together almost all the modern web tools: JsHint, CssLint, JsMin, Google Closure compressor, YUI Compressor, UglifyJs, Dojo Shrinksafe, Css Variables Support, JSON Compression, Less, Sass, CoffeeScript and <a href="http://code.google.com/p/wro4j/wiki/Features">much more</a>.
+    <a href="https://github.com/wro4j/wro4j">Wro4j</a> is a tool for analysis and optimization of web resources. It brings together almost all the modern web tools: JsHint, CssLint, JsMin, Google Closure compressor, YUI Compressor, UglifyJs, Dojo Shrinksafe, Css Variables Support, JSON Compression, Less, Sass, CoffeeScript and <a href="http://code.google.com/p/wro4j/wiki/Features">much more</a>.
     </p>
     <p>
       In order to get started with wro4j, you have to follow only <b style="font-size: 1.5em;color: red;">3</b> simple steps.
@@ -70,10 +70,10 @@
 	
 	<h1>Liked it?</h1>
 	<p>
-	  More detailed documentation about wro4j project is located on <a href="http://code.google.com/p/wro4j/">google code home page</a>.
+	  More detailed documentation about wro4j project is located on <a href="https://github.com/wro4j/wro4j">github.com/wro4j</a>.
 	</p>  
 	<p>
-	  There you will find out about the <a href="http://code.google.com/p/wro4j/wiki/DesignOverview">wro4j design overview<a>, other <a href="http://code.google.com/p/wro4j/wiki/Features">dozen of features</a> and how to use wro4j as a maven plugin or from the command line using wro4j-runner utility. Also, you will be able to learn how to extend wro4j with custom features and other useful tricks.
+	  There you will find out about the <a href="https://github.com/wro4j/wro4j/blob/master/docs/DesignOverview.md">wro4j design overview<a>, other <a href="http://code.google.com/p/wro4j/wiki/Features">dozen of features</a> and how to use wro4j as a maven plugin or from the command line using wro4j-runner utility. Also, you will be able to learn how to extend wro4j with custom features and other useful tricks.
 	</p>
   </div>  
   


### PR DESCRIPTION
This removes the google code links on the homepage I just stumbled upon. 