### PR TITLE
Make the wro4j-maven-plugin work in builds that use Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <closure.version>v20160315</closure.version>
         <slf4j.version>1.7.16</slf4j.version>
         <maven.version>3.0.4</maven.version>
-        <mockito.version>2.7.6</mockito.version>
+        <mockito.version>2.25.0</mockito.version>
         <junit.version>4.12</junit.version>
 	    <jruby.version>9.0.5.0</jruby.version>
         <spring.version>3.1.1.RELEASE</spring.version>
@@ -318,6 +318,11 @@
         </resources>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.6.0</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
The changes in this PR allow the wro4j-maven-plugin to work in builds that run with Java 11.

The test failures are the same as before these changes, so this PR does not introduce new test failures.

I verified the build with Java 8 and Java 11:
java version "1.8.0_202"
Java(TM) SE Runtime Environment (build 1.8.0_202-b08)
Java HotSpot(TM) 64-Bit Server VM (build 25.202-b08, mixed mode)

openjdk version "11.0.2" 2019-01-15
OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)