### PR TITLE
Fix a flaky test

### DIFF
--- a/wro4j-extensions/src/test/java/ro/isdc/wro/extensions/http/handler/TestModelAsJsonRequestHandler.java
+++ b/wro4j-extensions/src/test/java/ro/isdc/wro/extensions/http/handler/TestModelAsJsonRequestHandler.java
@@ -9,6 +9,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -107,7 +111,11 @@ public class TestModelAsJsonRequestHandler {
   public void shouldGenerateModelAsJson()
       throws Exception {
     victim.handle(mockRequest, mockResponse);
-    assertEquals(readJsonFile("wroModel_simple.json"), outputStream.toString());
+    ObjectMapper mapper = new ObjectMapper(); 
+    mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true); 
+    ObjectNode expected = mapper.readValue(readJsonFile("wroModel_simple.json"), ObjectNode.class); 
+    ObjectNode actual = mapper.readValue(outputStream.toString(), ObjectNode.class); 
+    assertEquals(expected, actual); 
   }
 
   @Test


### PR DESCRIPTION
This PR is to fix a flaky test `ro.isdc.wro.extensions.http.handler.TestModelAsJsonRequestHandler.shouldGenerateModelAsJson` in module `wro4j-extensions`.

### Test failures and Root cause

When running `ro.isdc.wro.extensions.http.handler.TestModelAsJsonRequestHandler.shouldGenerateModelAsJson` for several times, it can fail with the following error:
```
rg.junit.ComparisonFailure: 
expected:<...ps": [
    {
      "[name": "test",
      "resources": [
        {
          "type": "JS",
          "minimize": true,
          "uri": "test.js",
          "proxyUri": "/wro/?wroAPI=wroResources&id=test.js"
        }
      ]]
    }
  ]
}> but was:<...ps": [
    {
      "[resources": [
        {
          "type": "JS",
          "minimize": true,
          "uri": "test.js",
          "proxyUri": "/wro/?wroAPI=wroResources&id=test.js"
        }
      ],
      "name": "test"]
    }
  ]
}>
```
The root cause is that in line 110, the assertion assumes the order of all elements from `Json` is always consistent, which actually is not, therefore leading to test failures.

### Fix
To fix the flaky test, we can sort the nodes of the two `Json` string, which can avoid test failures caused by non-determinism.
